### PR TITLE
Fix "preg_match() expects parameter 2 to be string, bool given"

### DIFF
--- a/src/Method/HttpHeader.php
+++ b/src/Method/HttpHeader.php
@@ -69,7 +69,7 @@ class HttpHeader implements AuthInterface
     {
         $authHeaders = $request->getHeader($this->headerName);
         $authHeader = \reset($authHeaders);
-        if ($authHeader !== null) {
+        if (!empty($authHeader)) {
             if ($this->pattern !== null) {
                 if (preg_match($this->pattern, $authHeader, $matches)) {
                     $authHeader = $matches[1];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

`reset()` return `false` if `$authHeaders` is empty array
