### PR TITLE
Fix initialization error

### DIFF
--- a/src/Method/HttpBearer.php
+++ b/src/Method/HttpBearer.php
@@ -15,7 +15,7 @@ final class HttpBearer extends HttpHeader
     private const PATTERN = '/^Bearer\s+(.*?)$/';
 
     protected string $headerName = self::HEADER_NAME;
-    protected string $pattern = self::PATTERN;
+    protected ?string $pattern = self::PATTERN;
     /**
      * @var string the HTTP authentication realm
      */

--- a/src/Method/HttpBearer.php
+++ b/src/Method/HttpBearer.php
@@ -15,7 +15,7 @@ final class HttpBearer extends HttpHeader
     private const PATTERN = '/^Bearer\s+(.*?)$/';
 
     protected string $headerName = self::HEADER_NAME;
-    protected ?string $pattern = self::PATTERN;
+    protected string $pattern = self::PATTERN;
     /**
      * @var string the HTTP authentication realm
      */

--- a/src/Method/HttpHeader.php
+++ b/src/Method/HttpHeader.php
@@ -20,6 +20,8 @@ use Yiisoft\Auth\IdentityRepositoryInterface;
 class HttpHeader implements AuthInterface
 {
     private const HEADER_NAME = 'X-Api-Key';
+    private const PATTERN = '/(.*)/';
+
     /**
      * @var string the HTTP header name
      */
@@ -28,7 +30,7 @@ class HttpHeader implements AuthInterface
     /**
      * @var string a pattern to use to extract the HTTP authentication value
      */
-    protected ?string $pattern = null;
+    protected string $pattern = self::PATTERN;
 
     /**
      * @var IdentityRepositoryInterface
@@ -70,12 +72,10 @@ class HttpHeader implements AuthInterface
         $authHeaders = $request->getHeader($this->headerName);
         $authHeader = \reset($authHeaders);
         if (!empty($authHeader)) {
-            if ($this->pattern !== null) {
-                if (preg_match($this->pattern, $authHeader, $matches)) {
-                    $authHeader = $matches[1];
-                } else {
-                    return null;
-                }
+            if (preg_match($this->pattern, $authHeader, $matches)) {
+                $authHeader = $matches[1];
+            } else {
+                return null;
             }
             return $authHeader;
         }

--- a/src/Method/HttpHeader.php
+++ b/src/Method/HttpHeader.php
@@ -28,12 +28,12 @@ class HttpHeader implements AuthInterface
     /**
      * @var string a pattern to use to extract the HTTP authentication value
      */
-    protected string $pattern;
+    protected ?string $pattern = null;
 
     /**
      * @var IdentityRepositoryInterface
      */
-    protected $identityRepository;
+    protected IdentityRepositoryInterface $identityRepository;
 
     public function __construct(IdentityRepositoryInterface $identityRepository)
     {

--- a/src/Method/HttpHeader.php
+++ b/src/Method/HttpHeader.php
@@ -30,9 +30,6 @@ class HttpHeader implements AuthInterface
      */
     protected ?string $pattern = null;
 
-    /**
-     * @var IdentityRepositoryInterface
-     */
     protected IdentityRepositoryInterface $identityRepository;
 
     public function __construct(IdentityRepositoryInterface $identityRepository)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | fix initialization error

```
Typed property Yiisoft\Auth\Method\HttpHeader::$pattern must not be accessed before initialization
```