### PR TITLE
Fix #92: Use `SensitiveParameter` attribute to mark sensitive parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.2 under development
 
-- no changes in this release.
+- Enh #92: Use `SensitiveParameter` attribute to mark sensitive parameters (@ev-gor)
 
 ## 3.1.1 May 06, 2024
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $authenticationMethod = (new \Yiisoft\Auth\Method\HttpBasic($identityRepository)
     ->withRealm('Admin')
     ->withAuthenticationCallback(static function (
         ?string $username,
-        ?string $password,
+        #[\SensitiveParameter] ?string $password,
         \Yiisoft\Auth\IdentityWithTokenRepositoryInterface $identityRepository
     ): ?\Yiisoft\Auth\IdentityInterface {
         return $identityRepository->findIdentityByToken($username, \Yiisoft\Auth\Method\HttpBasic::class);

--- a/src/Method/HttpBasic.php
+++ b/src/Method/HttpBasic.php
@@ -67,8 +67,8 @@ final class HttpBasic implements AuthenticationMethodInterface
      *
      * ```php
      * static function (
-     *     string $username,
-     *     string $password,
+     *     ?string $username,
+     *     #[\SensitiveParameter] ?string $password,
      *     \Yiisoft\Auth\IdentityRepositoryInterface $identityRepository
      * ): ?\Yiisoft\Auth\IdentityInterface
      * ```
@@ -159,7 +159,7 @@ final class HttpBasic implements AuthenticationMethodInterface
         return $request->getServerParams()['REDIRECT_HTTP_AUTHORIZATION'] ?? null;
     }
 
-    private function extractCredentialsFromHeader(string $authToken): array
+    private function extractCredentialsFromHeader(#[\SensitiveParameter] string $authToken): array
     {
         return array_map(
             static fn ($value) => $value === '' ? null : $value,
@@ -167,7 +167,7 @@ final class HttpBasic implements AuthenticationMethodInterface
         );
     }
 
-    private function isBasicToken(string $token): bool
+    private function isBasicToken(#[\SensitiveParameter] string $token): bool
     {
         return strncasecmp($token, 'basic', 5) === 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #89
