### PR TITLE
Refactor failure handler to use dedicated interface instead of RequestHandlerInterface

### DIFF
--- a/src/AuthenticationMethodInterface.php
+++ b/src/AuthenticationMethodInterface.php
@@ -2,32 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Auth;
+namespace Yiisoft\Auth\Handler;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * The interface that should be implemented by individual authentication methods.
+ * Handles authentication failure.
+ * This is not a PSR-15 request handler.
  */
-interface AuthenticationMethodInterface
+interface AuthenticationFailureHandlerInterface
 {
-    /**
-     * Authenticates the identity based on information available from request.
-     *
-     * @param ServerRequestInterface $request Request to get identity information from.
-     *
-     * @return IdentityInterface|null An instance of identity or null if there is no match.
-     */
-    public function authenticate(ServerRequestInterface $request): ?IdentityInterface;
-
-    /**
-     * Adds challenge to response upon authentication failure.
-     * For example, some appropriate HTTP headers may be added.
-     *
-     * @param ResponseInterface $response Response to modify.
-     *
-     * @return ResponseInterface Modified response.
-     */
-    public function challenge(ResponseInterface $response): ResponseInterface;
+    public function handle(ServerRequestInterface $request): ResponseInterface;
 }

--- a/src/Handler/AuthenticationFailureHandler.php
+++ b/src/Handler/AuthenticationFailureHandler.php
@@ -7,13 +7,13 @@ namespace Yiisoft\Auth\Handler;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use Yiisoft\Http\Status;
 
 /**
- * Default authentication failure handler. Responds with "401 Unauthorized" HTTP status code.
+ * Default authentication failure handler.
+ * Returns 401 Unauthorized response.
  */
-final class AuthenticationFailureHandler implements RequestHandlerInterface
+final class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
 {
     public function __construct(
         private readonly ResponseFactoryInterface $responseFactory,
@@ -22,9 +22,7 @@ final class AuthenticationFailureHandler implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $response = $this->responseFactory->createResponse(Status::UNAUTHORIZED);
-        $response
-            ->getBody()
-            ->write('Your request was made with invalid credentials.');
+        $response->getBody()->write('Your request was made with invalid credentials.');
         return $response;
     }
 }

--- a/tests/AuthenticationFailureHandlerTest.php
+++ b/tests/AuthenticationFailureHandlerTest.php
@@ -32,7 +32,7 @@ final class AuthenticationFailureHandlerTest extends TestCase
 
         $this->assertEquals(
             'Your request was made with invalid credentials.',
-            (string) $response->getBody()
+            (string) $response->getBody(),
         );
     }
 

--- a/tests/AuthenticationFailureHandlerTest.php
+++ b/tests/AuthenticationFailureHandlerTest.php
@@ -9,6 +9,7 @@ use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Yiisoft\Auth\Handler\AuthenticationFailureHandler;
+use Yiisoft\Auth\Handler\AuthenticationFailureHandlerInterface;
 use Yiisoft\Http\Method;
 use Yiisoft\Http\Status;
 
@@ -19,6 +20,7 @@ final class AuthenticationFailureHandlerTest extends TestCase
         $response = $this
             ->createHandler()
             ->handle($this->createRequest());
+
         $this->assertEquals(Status::UNAUTHORIZED, $response->getStatusCode());
     }
 
@@ -27,10 +29,14 @@ final class AuthenticationFailureHandlerTest extends TestCase
         $response = $this
             ->createHandler()
             ->handle($this->createRequest());
-        $this->assertEquals('Your request was made with invalid credentials.', (string) $response->getBody());
+
+        $this->assertEquals(
+            'Your request was made with invalid credentials.',
+            (string) $response->getBody()
+        );
     }
 
-    private function createHandler(): AuthenticationFailureHandler
+    private function createHandler(): AuthenticationFailureHandlerInterface
     {
         return new AuthenticationFailureHandler(new Psr17Factory());
     }

--- a/tests/AuthenticationMiddlewareTest.php
+++ b/tests/AuthenticationMiddlewareTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Server\AuthenticationFailureHandlerInterface;
 use Yiisoft\Auth\AuthenticationMethodInterface;
 use Yiisoft\Auth\IdentityInterface;
 use Yiisoft\Auth\Middleware\Authentication;
@@ -41,7 +41,7 @@ final class AuthenticationMiddlewareTest extends TestCase
             ->method('authenticate')
             ->willReturn($identity);
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler = $this->createMock(AuthenticationFailureHandlerInterface::class);
         $handler
             ->expects($this->once())
             ->method('handle')
@@ -75,7 +75,7 @@ final class AuthenticationMiddlewareTest extends TestCase
             ->method('authenticate')
             ->willReturn(null);
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler = $this->createMock(AuthenticationFailureHandlerInterface::class);
         $handler
             ->expects($this->once())
             ->method('handle');
@@ -103,7 +103,7 @@ final class AuthenticationMiddlewareTest extends TestCase
                 static fn(ResponseInterface $response) => $response->withHeader($header, $headerValue),
             );
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler = $this->createMock(AuthenticationFailureHandlerInterface::class);
         $handler
             ->expects($this->never())
             ->method('handle');
@@ -132,7 +132,7 @@ final class AuthenticationMiddlewareTest extends TestCase
                 static fn(ResponseInterface $response) => $response->withHeader($header, $headerValue),
             );
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler = $this->createMock(AuthenticationFailureHandlerInterface::class);
         $handler
             ->expects($this->never())
             ->method('handle');
@@ -160,9 +160,9 @@ final class AuthenticationMiddlewareTest extends TestCase
         $this->assertNotSame($original, $original->withOptionalPatterns(['test']));
     }
 
-    private function createAuthenticationFailureHandler(string $failureResponse): RequestHandlerInterface
+    private function createAuthenticationFailureHandler(string $failureResponse): AuthenticationFailureHandlerInterface
     {
-        return new class ($failureResponse, new Psr17Factory()) implements RequestHandlerInterface {
+        return new class ($failureResponse, new Psr17Factory()) implements AuthenticationFailureHandlerInterface {
             public function __construct(
                 private readonly string $failureResponse,
                 private readonly ResponseFactoryInterface $responseFactory,


### PR DESCRIPTION
This PR removes misuse of PSR-15 RequestHandlerInterface for authentication failure handling
and introduces a dedicated AuthenticationFailureHandlerInterface with a clear contract.

Failure handlers are now middleware-specific and no longer pretend to be part of the PSR-15 pipeline.
Fixes #106

