### PR TITLE
Fix #116: Fix authentication scheme in `HttpBearer` challenge according to RFC 6750

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.2.2 under development
 
-- Bug #116: Fix authentication scheme in `HttpBearer` challenge (@samdark)
+- Bug #116: Fix authentication scheme in `HttpBearer` challenge according to RFC 6750 (@samdark)
 - Chg #104: Bump minimal PHP version to 8.1 (@vjik)
 - Enh #104: Explicitly mark readonly properties (@vjik)
 - Enh #105: Explicitly import classes and functions in "use" section (@mspirkov)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.2.2 under development
 
+- Bug #116: Fix authentication scheme in `HttpBearer` challenge (@samdark)
 - Chg #104: Bump minimal PHP version to 8.1 (@vjik)
 - Enh #104: Explicitly mark readonly properties (@vjik)
 - Enh #105: Explicitly import classes and functions in "use" section (@mspirkov)

--- a/src/Method/HttpBearer.php
+++ b/src/Method/HttpBearer.php
@@ -25,7 +25,7 @@ final class HttpBearer extends HttpHeader
 
     public function challenge(ResponseInterface $response): ResponseInterface
     {
-        return $response->withHeader(Header::WWW_AUTHENTICATE, "{$this->headerName} realm=\"{$this->realm}\"");
+        return $response->withHeader(Header::WWW_AUTHENTICATE, "Bearer realm=\"{$this->realm}\"");
     }
 
     /**

--- a/tests/Method/CompositeTest.php
+++ b/tests/Method/CompositeTest.php
@@ -103,7 +103,7 @@ final class CompositeTest extends TestCase
         ]));
 
         $this->assertEquals(
-            'Authorization realm="api"',
+            'Bearer realm="api"',
             $authenticationMethod
                 ->challenge($response)
                 ->getHeaderLine(Header::WWW_AUTHENTICATE),

--- a/tests/Method/HttpBearerTest.php
+++ b/tests/Method/HttpBearerTest.php
@@ -56,7 +56,7 @@ final class HttpBearerTest extends TestCase
         $authenticationMethod = new HttpBearer($identityRepository);
 
         $this->assertEquals(
-            'Authorization realm="api"',
+            'Bearer realm="api"',
             $authenticationMethod
                 ->challenge($response)
                 ->getHeaderLine(Header::WWW_AUTHENTICATE),
@@ -71,7 +71,7 @@ final class HttpBearerTest extends TestCase
             ->withRealm('gateway');
 
         $this->assertEquals(
-            'Authorization realm="gateway"',
+            'Bearer realm="gateway"',
             $authenticationMethod
                 ->challenge($response)
                 ->getHeaderLine(Header::WWW_AUTHENTICATE),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #116

Use the `Bearer` authentication scheme in `HttpBearer::challenge()` as required by RFC 6750, instead of using the request header name. Update the corresponding challenge assertions and changelog entry.

Closes #116.