### PR TITLE
Fix #124: Fix `HttpBasic` and `HttpBearer` to add `WWW-Authenticate` header instead of overwriting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.1 under development
 
-- no changes in this release.
+- Bug #124: Fix `HttpBasic` and `HttpBearer` to add `WWW-Authenticate` header instead of overwriting it (@vjik)
 
 ## 3.3.0 August 06, 2026
 

--- a/src/Method/HttpBasic.php
+++ b/src/Method/HttpBasic.php
@@ -63,7 +63,7 @@ final class HttpBasic implements AuthenticationMethodInterface, AuthenticatorWit
 
     public function challenge(ResponseInterface $response): ResponseInterface
     {
-        return $response->withHeader(Header::WWW_AUTHENTICATE, "Basic realm=\"{$this->realm}\"");
+        return $response->withAddedHeader(Header::WWW_AUTHENTICATE, "Basic realm=\"{$this->realm}\"");
     }
 
     /**

--- a/src/Method/HttpBearer.php
+++ b/src/Method/HttpBearer.php
@@ -28,7 +28,7 @@ final class HttpBearer extends HttpHeader implements AuthenticatorWithChallengeI
 
     public function challenge(ResponseInterface $response): ResponseInterface
     {
-        return $response->withHeader(Header::WWW_AUTHENTICATE, "Bearer realm=\"{$this->realm}\"");
+        return $response->withAddedHeader(Header::WWW_AUTHENTICATE, "Bearer realm=\"{$this->realm}\"");
     }
 
     /**

--- a/tests/Method/CompositeTest.php
+++ b/tests/Method/CompositeTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Yiisoft\Auth\IdentityInterface;
 use Yiisoft\Auth\Method\Composite;
+use Yiisoft\Auth\Method\HttpBasic;
 use Yiisoft\Auth\Method\HttpBearer;
 use Yiisoft\Auth\Method\QueryParameter;
 use Yiisoft\Auth\Tests\Stub\FakeIdentity;
@@ -107,6 +108,25 @@ final class CompositeTest extends TestCase
             $authenticationMethod
                 ->challenge($response)
                 ->getHeaderLine(Header::WWW_AUTHENTICATE),
+        );
+    }
+
+    public function testChallengeAccumulatesHeadersFromMultipleMethods(): void
+    {
+        $response = new Response(400);
+        $identityRepository = new FakeIdentityRepository($this->createIdentity());
+
+        $authenticationMethod = new Composite([
+            new HttpBearer($identityRepository),
+            new HttpBasic($identityRepository),
+        ]);
+
+        $this->assertEquals(
+            [
+                'Bearer realm="api"',
+                'Basic realm="api"',
+            ],
+            $authenticationMethod->challenge($response)->getHeader(Header::WWW_AUTHENTICATE),
         );
     }
 

--- a/tests/Method/HttpBasicTest.php
+++ b/tests/Method/HttpBasicTest.php
@@ -136,6 +136,21 @@ final class HttpBasicTest extends TestCase
         );
     }
 
+    public function testChallengeAddsHeaderInsteadOfOverwritingExistingOne(): void
+    {
+        $response = (new Response())->withHeader(Header::WWW_AUTHENTICATE, 'Bearer realm="api"');
+        $identityRepository = new FakeIdentityRepository($this->createIdentity());
+        $authenticationMethod = new HttpBasic($identityRepository);
+
+        $this->assertEquals(
+            [
+                'Bearer realm="api"',
+                'Basic realm="api"',
+            ],
+            $authenticationMethod->challenge($response)->getHeader(Header::WWW_AUTHENTICATE),
+        );
+    }
+
     public function testInvalidHeaderName(): void
     {
         $encodeFields = base64_encode('admin:pass');

--- a/tests/Method/HttpBearerTest.php
+++ b/tests/Method/HttpBearerTest.php
@@ -78,6 +78,21 @@ final class HttpBearerTest extends TestCase
         );
     }
 
+    public function testChallengeAddsHeaderInsteadOfOverwritingExistingOne(): void
+    {
+        $response = (new Response())->withHeader(Header::WWW_AUTHENTICATE, 'Basic realm="api"');
+        $identityRepository = new FakeIdentityRepository($this->createIdentity());
+        $authenticationMethod = new HttpBearer($identityRepository);
+
+        $this->assertEquals(
+            [
+                'Basic realm="api"',
+                'Bearer realm="api"',
+            ],
+            $authenticationMethod->challenge($response)->getHeader(Header::WWW_AUTHENTICATE),
+        );
+    }
+
     public function testImmutability(): void
     {
         $identityRepository = new FakeIdentityRepository($this->createIdentity());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
Fix #124 