### PR TITLE
Document AuthenticatorInterface DI binding requirement for autowired Authentication middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 3.3.1 under development
 
-- no changes in this release.
+- Enh: Document `AuthenticatorInterface` DI binding requirement for autowired `Authentication` middleware
+  (@rossaddison)
 
 ## 3.3.0 August 06, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 3.3.1 under development
 
-- Enh #127: Document `AuthenticatorInterface` DI binding requirement for autowired `Authentication` middleware
-  (@rossaddison)
-
 ## 3.3.0 August 06, 2026
 
 - New #113: Split `AuthenticationMethodInterface` into focused authentication and challenge interfaces (@samdark, @vjik)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.1 under development
 
-- Enh: Document `AuthenticatorInterface` DI binding requirement for autowired `Authentication` middleware
+- Enh #127: Document `AuthenticatorInterface` DI binding requirement for autowired `Authentication` middleware
   (@rossaddison)
 
 ## 3.3.0 August 06, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.3.1 under development
 
+- no changes in this release.
+
 ## 3.3.0 August 06, 2026
 
 - New #113: Split `AuthenticationMethodInterface` into focused authentication and challenge interfaces (@samdark, @vjik)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,31 @@ public function actionIndex(\Psr\Http\Message\ServerRequestInterface $request): 
 }
 ```
 
+### Using with a DI container
+
+`Authentication`'s constructor requires `\Yiisoft\Auth\AuthenticatorInterface`. If your framework builds the
+middleware via autowiring — for example, applying it to a route by class name, as
+[yiisoft/router](https://github.com/yiisoft/router) groups commonly do (`->middleware(Authentication::class)`) —
+the container needs an explicit binding for `AuthenticatorInterface`, since there is no default implementation to
+autowire it to:
+
+```php
+// e.g. in config/web/di/auth.php
+AuthenticatorInterface::class => HttpBearer::class,
+```
+
+Without that binding, the container fails with a message that doesn't name the actual gap:
+
+```
+No definition or class found for "Yiisoft\Auth\Middleware\Authentication" ID.
+No definition or class found or resolvable for "Yiisoft\Auth\AuthenticatorInterface"
+while building "Yiisoft\Auth\Middleware\Authentication" -> "Yiisoft\Auth\AuthenticatorInterface".
+```
+
+If HTTP-challenge-style authentication isn't what you need for a given route — session/cookie-based login instead,
+for example — don't apply this middleware there at all; binding an authenticator you don't otherwise use just to
+satisfy the container isn't the fix.
+
 ### HTTP basic authentication
 
 Basic HTTP authentication is typically used for entering login and password in the browser.

--- a/README.md
+++ b/README.md
@@ -56,28 +56,19 @@ public function actionIndex(\Psr\Http\Message\ServerRequestInterface $request): 
 
 ### Using with a DI container
 
-`Authentication`'s constructor requires `\Yiisoft\Auth\AuthenticatorInterface`. If your framework builds the
-middleware via autowiring — for example, applying it to a route by class name, as
-[yiisoft/router](https://github.com/yiisoft/router) groups commonly do (`->middleware(Authentication::class)`) —
-the container needs an explicit binding for `AuthenticatorInterface`, since there is no default implementation to
-autowire it to:
+e.g. recurring invoice monthly cron
 
 ```php
-// e.g. in config/web/di/auth.php
-AuthenticatorInterface::class => HttpBearer::class,
-```
+use App\Invoice\InvRecurring\CronTokenRepository;
+use Yiisoft\Auth\AuthenticatorInterface;
+use Yiisoft\Auth\Method\HttpBearer;
 
-Without that binding, the container fails with a message that doesn't name the actual gap:
+return [
+    AuthenticatorInterface::class => static fn (CronTokenRepository $cronTokenRepository): HttpBearer =>
+        new HttpBearer($cronTokenRepository),
+];
 
 ```
-No definition or class found for "Yiisoft\Auth\Middleware\Authentication" ID.
-No definition or class found or resolvable for "Yiisoft\Auth\AuthenticatorInterface"
-while building "Yiisoft\Auth\Middleware\Authentication" -> "Yiisoft\Auth\AuthenticatorInterface".
-```
-
-If HTTP-challenge-style authentication isn't what you need for a given route — session/cookie-based login instead,
-for example — don't apply this middleware there at all; binding an authenticator you don't otherwise use just to
-satisfy the container isn't the fix.
 
 ### HTTP basic authentication
 

--- a/README.md
+++ b/README.md
@@ -56,19 +56,20 @@ public function actionIndex(\Psr\Http\Message\ServerRequestInterface $request): 
 
 ### Using with a DI container
 
-e.g. recurring invoice monthly cron
+When the `Yiisoft\Auth\Middleware\Authentication` middleware is created by a DI container (for example, when it is referenced by class name in router configuration), ensure the container can resolve `Yiisoft\Auth\AuthenticatorInterface` by binding it to a concrete authenticator:
 
-```php
-use App\Invoice\InvRecurring\CronTokenRepository;
+~~~php
 use Yiisoft\Auth\AuthenticatorInterface;
+use Yiisoft\Auth\IdentityWithTokenRepositoryInterface;
 use Yiisoft\Auth\Method\HttpBearer;
 
 return [
-    AuthenticatorInterface::class => static fn (CronTokenRepository $cronTokenRepository): HttpBearer =>
-        new HttpBearer($cronTokenRepository),
+    AuthenticatorInterface::class => static fn (IdentityWithTokenRepositoryInterface $identityRepository): AuthenticatorInterface =>
+        new HttpBearer($identityRepository),
 ];
+~~~
 
-```
+If a route does not require HTTP-challenge-style authentication, do not apply the `Authentication` middleware to it.
 
 ### HTTP basic authentication
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

## Summary

`Authentication`'s constructor requires `AuthenticatorInterface`, and the package ships no default
implementation for a container to autowire it to. That's fine when it's constructed manually (as the
existing "General usage" example shows), but when a framework builds the middleware via autowiring instead —
applying it to a route by class name, as `yiisoft/router` groups commonly do
(`->middleware(Authentication::class)`) — an unbound `AuthenticatorInterface` fails with a message that never
names the actual gap:

```
No definition or class found for "Yiisoft\Auth\Middleware\Authentication" ID.
No definition or class found or resolvable for "Yiisoft\Auth\AuthenticatorInterface"
while building "Yiisoft\Auth\Middleware\Authentication" -> "Yiisoft\Auth\AuthenticatorInterface".
```

We hit this for real in a production Yii3 app after adopting 3.3.0's `AuthenticatorInterface` split
(#113/#115): the middleware had been referenced via autowiring across most of the app's routes with no
binding ever configured — it had simply never actually been constructed until a compiled DI container cache
was invalidated by an unrelated `composer update`, at which point every one of those routes started 500ing.

This PR adds a short "Using with a DI container" section to the README documenting the binding requirement,
with an example, and explicitly naming the equally valid alternative when a route doesn't need
HTTP-challenge-style authentication at all: don't apply this middleware there, rather than binding an
authenticator you don't otherwise use just to satisfy the container.

## Related write-up

For anyone wanting the fuller story (including the exact production exception, the fix, and a plain-English
explainer on when an app would actually need `WWW-Authenticate`-style auth vs. session-based login):
https://github.com/rossaddison/invoice/blob/main/docs/AUTHENTICATION_DI_CRASH_FIX_AUGUST_2026.md and
https://github.com/rossaddison/invoice/blob/main/docs/WWW_AUTHENTICATE_VS_SESSION_AUTH_AUGUST_2026.md
(the latter also has Persian/Portuguese translations, if useful to anyone on the team or in the wider
community).

Happy to adjust wording/placement if you'd rather this live in `docs/internals.md` instead, or if you'd
prefer the constructor itself to throw a more specific exception rather than (or in addition to) documenting
it — from what I can tell the current message actually originates in `yiisoft/di`'s generic resolution
failure, not in this package, so a code-level fix may not be in scope here at all.
