### PR TITLE
Fix BC-breaking change in `Authentication` middleware constructor parameter type

### DIFF
--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -2,11 +2,5 @@
     xsi:noNamespaceSchemaLocation="vendor/roave/backward-compatibility-check/Resources/schema.xsd">
     <baseline>
         <ignored-regex>#\[BC\] SKIPPED: Roave\\BetterReflection\\Reflection\\ReflectionClass "Yiisoft\\Yii\\Debug#</ignored-regex>
-        <!--
-        AuthenticationMethodInterface now extends AuthenticatorInterface, so accepting AuthenticatorInterface widens
-        the constructor parameter type. Roave compares the two package versions independently and cannot resolve this
-        newly introduced cross-version parent relationship as contravariant.
-        -->
-        <ignored-regex>#^\[BC\] CHANGED: The parameter \$authenticationMethod of Yiisoft\\Auth\\Middleware\\Authentication\#__construct\(\) changed from Yiisoft\\Auth\\AuthenticationMethodInterface to a non-contravariant Yiisoft\\Auth\\AuthenticatorInterface$#</ignored-regex>
     </baseline>
 </roave-bc-check>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.3.1 under development
 
 - Bug #124: Fix `HttpBasic` and `HttpBearer` to add `WWW-Authenticate` header instead of overwriting it (@vjik)
+- Bug #128: Fix BC-breaking change in `Authentication` middleware constructor parameter type (@vjik)
 
 ## 3.3.0 August 06, 2026
 

--- a/src/Middleware/Authentication.php
+++ b/src/Middleware/Authentication.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Auth\AuthenticationMethodInterface;
 use Yiisoft\Auth\AuthenticatorInterface;
 use Yiisoft\Auth\AuthenticatorWithChallengeInterface;
 use Yiisoft\Auth\Handler\AuthenticationFailureHandler;
@@ -36,7 +37,7 @@ final class Authentication implements MiddlewareInterface
     private array $wildcards = [];
 
     public function __construct(
-        private AuthenticatorInterface $authenticationMethod,
+        private AuthenticatorInterface|AuthenticationMethodInterface $authenticationMethod,
         ResponseFactoryInterface $responseFactory,
         ?RequestHandlerInterface $authenticationFailureHandler = null,
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

See https://github.com/yiisoft/demo-diary/issues/105